### PR TITLE
Functionality to Convert Subsystem to Simulink Function

### DIFF
--- a/src/isGoodSimFcnName.m
+++ b/src/isGoodSimFcnName.m
@@ -1,0 +1,35 @@
+function goodName = isGoodSimFcnName(subsystem, simulinkFcnName)
+% isGoodSimFcnName          Checks to see if a Simulink-fcn name clashes with
+%                           any other Simulink-fcns in scope at the current
+%                           subsystem level
+% Inputs:
+%   subsystem               Path of a subsystem where the fcn will be added
+%   simulinkFcnName         Name of the Simulink-function to be created
+%
+% Outputs:
+%   goodName                Name can be used(1) or not(0)
+%
+% Example:
+%   isGoodSimFcnName('SubSystem_Name','SimFcnName')
+%
+%           ans = 1
+
+    % Get callable Simulink-functions at the current scope
+    [~, prototype] = getCallableFunctions(subsystem);
+    
+    result = zeros(1, length(prototype));
+    
+    splitEquals = split(prototype, '= ');
+    % Loop through each fcn name and compare to the input name
+    for fcn = 1:length(prototype)
+        if length(prototype) == 1
+            splitHierarchy = split(splitEquals{end}, '.');
+        else
+            splitHierarchy = split(splitEquals{fcn,end}, '.');
+        end
+        tmp = split(splitHierarchy{end}, '(');
+        result(fcn) = ~strcmp(simulinkFcnName, tmp{1});
+    end
+    % Return true if none of the fcn names are the same as the input name
+    goodName = all(result);
+end

--- a/src/isGoodSimFcnName.m
+++ b/src/isGoodSimFcnName.m
@@ -1,20 +1,21 @@
 function goodName = isGoodSimFcnName(subsystem, simulinkFcnName)
-% isGoodSimFcnName          Checks to see if a Simulink-fcn name clashes with
-%                           any other Simulink-fcns in scope at the current
-%                           subsystem level
+% isGoodSimFcnName          Checks to see if a Simulink Function name is the
+%                           same as any other Simulink Functions in scope at
+%                           the current subsystem level
 % Inputs:
-%   subsystem               Path of a subsystem where the fcn will be added
-%   simulinkFcnName         Name of the Simulink-function to be created
+%   subsystem               Path of a subsystem where a Simulink Function
+%                           will be added
+%   simulinkFcnName         Name of the Simulink Function to be added
 %
 % Outputs:
 %   goodName                Name can be used(1) or not(0)
 %
 % Example:
-%   isGoodSimFcnName('SubSystem_Name','SimFcnName')
+%   isGoodSimFcnName('SubSystem_Name', 'SimFcnName')
 %
 %           ans = 1
 
-    % Get callable Simulink-functions at the current scope
+    % Get callable Simulink Functions at the current scope
     [~, prototype] = getCallableFunctions(subsystem);
     
     % Get the prototype names

--- a/src/isGoodSimFcnName.m
+++ b/src/isGoodSimFcnName.m
@@ -17,19 +17,21 @@ function goodName = isGoodSimFcnName(subsystem, simulinkFcnName)
     % Get callable Simulink-functions at the current scope
     [~, prototype] = getCallableFunctions(subsystem);
     
-    result = zeros(1, length(prototype));
+    % Get the prototype names
+    prototypeNames = getPrototypeName(prototype);
     
-    splitEquals = split(prototype, '= ');
-    % Loop through each fcn name and compare to the input name
-    for fcn = 1:length(prototype)
-        if length(prototype) == 1
-            splitHierarchy = split(splitEquals{end}, '.');
-        else
-            splitHierarchy = split(splitEquals{fcn,end}, '.');
-        end
-        tmp = split(splitHierarchy{end}, '(');
-        result(fcn) = ~strcmp(simulinkFcnName, tmp{1});
+    % Make sure the prototype name is a cell
+    if ~iscell(prototypeNames)
+        prototypeNames = {prototypeNames};
     end
-    % Return true if none of the fcn names are the same as the input name
+    
+    result = zeros(1, length(prototypeNames));
+    
+    % Loop through each prototype name
+    for name = 1:length(prototypeNames)
+        % Compare to the input name
+        result(name) = ~strcmp(simulinkFcnName, prototypeNames{name});
+    end
+    % Return true if none of the prototype names are the same as the input name
     goodName = all(result);
 end

--- a/src/isSubsystem.m
+++ b/src/isSubsystem.m
@@ -1,4 +1,4 @@
-function b = isSubsystem(block)
+function b = isSubsystem(blocks)
 % ISSUBSYSTEM Determine if the block is a subsystem.
 %
 %   Inputs:
@@ -7,8 +7,15 @@ function b = isSubsystem(block)
 %   Outputs:
 %       b       Whether the block is a subsystem(1) or not(0).
     
-    % Strip block from cell array
-    block = block{1};
-    % Check if block is a subsystem
-    b = strcmpi(get_param(block,'BlockType'),'SubSystem');
+    % Convert the input to handles
+    blocks = inputToNumeric(blocks);
+    
+    b = zeros(1, length(blocks));
+    % Check each block to see if its a subsystem
+    for block = 1:length(blocks)
+        try
+            b(block) = strcmpi(get_param(blocks(block),'BlockType'),'SubSystem');
+        catch % Unexpected error
+        end
+    end
 end

--- a/src/isSubsystem.m
+++ b/src/isSubsystem.m
@@ -1,0 +1,14 @@
+function b = isSubsystem(block)
+% ISSUBSYSTEM Determine if the block is a subsystem.
+%
+%   Inputs:
+%       block   Pathname or handle of a block.
+%
+%   Outputs:
+%       b       Whether the block is a subsystem(1) or not(0).
+    
+    % Strip block from cell array
+    block = block{1};
+    % Check if block is a subsystem
+    b = strcmpi(get_param(block,'BlockType'),'SubSystem');
+end

--- a/src/isSubsystem.m
+++ b/src/isSubsystem.m
@@ -14,7 +14,8 @@ function b = isSubsystem(blocks)
     % Check each block to see if its a subsystem
     for block = 1:length(blocks)
         try
-            b(block) = strcmpi(get_param(blocks(block),'BlockType'),'SubSystem');
+            blockType = get_param(blocks(block), 'BlockType');
+            b(block) = strcmpi(blockType, 'SubSystem');
         catch % Unexpected error
         end
     end

--- a/src/reqSimFcnName.m
+++ b/src/reqSimFcnName.m
@@ -25,7 +25,7 @@ function simulinkFcnName = reqSimFcnName()
     while 1
         inputName = inputdlg(prompt, dlgtitle, dims, definput);
         % Checks to see if the name shadows other names in scope
-        if isGoodSimFcnName(gcs,inputName{1})
+        if isGoodSimFcnName(gcs, inputName{1})
             break
         else
             waitfor(msgbox([inputName{1}, ...

--- a/src/reqSimFcnName.m
+++ b/src/reqSimFcnName.m
@@ -1,0 +1,37 @@
+function simulinkFcnName = reqSimFcnName()
+% getSimFcnName             Prompts the user for an input Simulink Function name
+%                           until a name is entered which is not the same as
+%                           another Simulink Function in scope
+%                                                 
+% Inputs:
+%   N/A
+%
+% Outputs:
+%   simulinkFcnName         Char array which represents a Simulink Function name
+%
+% Example:
+%   simulinkFcnName = getSimFcnName()
+%
+%           ans = 'Function_Name'
+
+    %% Dialog Box Parameters
+    prompt = 'Enter a name for the Simulink Function: ';
+    dlgtitle = 'Convert Subsystem';
+    dims = [1 50];
+    definput = {'f'};
+            
+    %% Checking Input
+    % Loop until the input name is acceptable
+    while 1
+        inputName = inputdlg(prompt, dlgtitle, dims, definput);
+        % Checks to see if the name shadows other names in scope
+        if isGoodSimFcnName(gcs,inputName{1})
+            break
+        else
+            waitfor(msgbox([inputName{1}, ...
+                    ' is already used as a Simulink Function in scope.', ...
+                     newline, newline, 'Please enter a new name.'], dlgtitle));
+        end
+    end
+    simulinkFcnName = inputName{1};
+end

--- a/src/sl_customization.m
+++ b/src/sl_customization.m
@@ -16,7 +16,44 @@ function schemaFcns = getSLModuleTool(callbackInfo)
     elseif any(selectedFcns) && ~isempty(gcbs)
         schemaFcns{end+1} = @ChangeFcnScopeSchema;
         schemaFcns{end+1} = @FcnCreatorLocalSchema;
+    elseif isSubsystem(gcbs)
+        schemaFcns{end+1} = @ConvToSimFcnSchema;
     end
+end
+
+%% Define action: Convert Subsystem to Simulink-function
+function schema = ConvToSimFcnSchema(callbackInfo)
+    schema = sl_container_schema;
+    schema.label = 'Convert Subsystem';
+    schema.ChildrenFcns = {@toScopedSimFcn,@toGlobalSimFcn};
+end
+
+function schema=toScopedSimFcn(callbackInfo)
+    schema = sl_action_schema;
+    schema.label = 'to Scoped Simulink Function';
+    schema.userdata = 'toScopedSimFcn';
+    schema.callback = @toScopedSimFcnCallback;
+end
+
+function toScopedSimFcnCallback(callbackInfo)
+    simulinkFunctionName = ...
+        input('Enter a name for the Simulink-function: ','s');
+    subsystem = gcbs;
+    subToSimFcn(subsystem{1},simulinkFunctionName,'scoped');
+end
+
+function schema=toGlobalSimFcn(callbackInfo)
+    schema = sl_action_schema;
+    schema.label = 'to Global Simulink Function';
+    schema.userdata = 'toGlobalSimFcn';
+    schema.callback = @toGlobalSimFcnCallback;
+end
+
+function toGlobalSimFcnCallback(callbackInfo)
+    simulinkFunctionName = ...
+        input('Enter a name for the Simulink-function: ','s');
+    subsystem = gcbs;
+    subToSimFcn(subsystem{1},simulinkFunctionName,'global');
 end
 
 %% Define action: Create Function Caller for Local Function

--- a/src/sl_customization.m
+++ b/src/sl_customization.m
@@ -25,35 +25,33 @@ end
 function schema = ConvToSimFcnSchema(callbackInfo)
     schema = sl_container_schema;
     schema.label = 'Convert Subsystem';
-    schema.ChildrenFcns = {@toScopedSimFcn,@toGlobalSimFcn};
+    schema.ChildrenFcns = {@toScopedSimFcn, @toGlobalSimFcn};
 end
 
 function schema=toScopedSimFcn(callbackInfo)
     schema = sl_action_schema;
-    schema.label = 'to Scoped Simulink Function';
+    schema.label = 'To Scoped Simulink Function';
     schema.userdata = 'toScopedSimFcn';
     schema.callback = @toScopedSimFcnCallback;
 end
 
 function toScopedSimFcnCallback(callbackInfo)
-    simulinkFunctionName = ...
-        input('Enter a name for the Simulink-function: ','s');
+    simulinkFcnName = reqSimFcnName();
     subsystem = gcbs;
-    subToSimFcn(subsystem{1},simulinkFunctionName,'scoped');
+    subToSimFcn(subsystem{1}, simulinkFcnName, 'scoped');
 end
 
 function schema=toGlobalSimFcn(callbackInfo)
     schema = sl_action_schema;
-    schema.label = 'to Global Simulink Function';
+    schema.label = 'To Global Simulink Function';
     schema.userdata = 'toGlobalSimFcn';
     schema.callback = @toGlobalSimFcnCallback;
 end
 
 function toGlobalSimFcnCallback(callbackInfo)
-    simulinkFunctionName = ...
-        input('Enter a name for the Simulink-function: ','s');
+    simulinkFcnName = reqSimFcnName();
     subsystem = gcbs;
-    subToSimFcn(subsystem{1},simulinkFunctionName,'global');
+    subToSimFcn(subsystem{1}, simulinkFcnName, 'global');
 end
 
 %% Define action: Create Function Caller for Local Function

--- a/src/sl_customization.m
+++ b/src/sl_customization.m
@@ -21,14 +21,14 @@ function schemaFcns = getSLModuleTool(callbackInfo)
     end
 end
 
-%% Define action: Convert Subsystem to Simulink-function
+%% Define action: Convert Subsystem to Simulink Function
 function schema = ConvToSimFcnSchema(callbackInfo)
     schema = sl_container_schema;
     schema.label = 'Convert Subsystem';
     schema.ChildrenFcns = {@toScopedSimFcn, @toGlobalSimFcn};
 end
 
-function schema=toScopedSimFcn(callbackInfo)
+function schema = toScopedSimFcn(callbackInfo)
     schema = sl_action_schema;
     schema.label = 'To Scoped Simulink Function';
     schema.userdata = 'toScopedSimFcn';
@@ -41,7 +41,7 @@ function toScopedSimFcnCallback(callbackInfo)
     subToSimFcn(subsystem{1}, simulinkFcnName, 'scoped');
 end
 
-function schema=toGlobalSimFcn(callbackInfo)
+function schema = toGlobalSimFcn(callbackInfo)
     schema = sl_action_schema;
     schema.label = 'To Global Simulink Function';
     schema.userdata = 'toGlobalSimFcn';

--- a/src/subToSimFcn.m
+++ b/src/subToSimFcn.m
@@ -1,10 +1,10 @@
-function subToSimFunc(subsystem,simulinkFunctionName,visibility)
-% subToSimFunc converts a subsystem to a Simulink-function
+function subToSimFcn(subsystem,simulinkFunctionName,visibility)
+% subToSimFunc              Converts a subsystem to a Simulink-function
 %
 % Inputs:
-%   subsystem           Path of a subsystem to be converted
-%   simulinkFunctionName     Name of the Simulink-function to be created
-%   visibility          Set function Visibility parameter to'scoped' or 'global'
+%   subsystem               Path of a subsystem to be converted
+%   simulinkFunctionName    Name of the Simulink-function to be created
+%   visibility              Set function visibility to'scoped' or 'global'
 %
 % Outputs:
 %   N/A
@@ -14,8 +14,6 @@ function subToSimFunc(subsystem,simulinkFunctionName,visibility)
 %
 %           Converts 'f_Sensor_Trip_1' subsystem to a
 %           scoped Simulink-function 'f_SensorTrip_i'
-%
-% Author: Stephen Scott
 
     %% Input Validation
     
@@ -72,15 +70,7 @@ function subToSimFunc(subsystem,simulinkFunctionName,visibility)
     allArgIns=find_system(subsystem,'SearchDepth',1,'BlockType','ArgIn');
     
     % Setting the parameters for all the argument inputs
-    for argIn=1:length(allArgIns)
-        set_param(allArgIns{argIn},'Port',inportParameters{argIn,1},...
-                  'OutMin',inportParameters{argIn,2},...
-                  'OutMax',inportParameters{argIn,3},...
-                  'OutDataTypeStr',inportParameters{argIn,4},...
-                  'LockScale',inportParameters{argIn,5},....
-                  'PortDimensions',inportParameters{argIn,6},...
-                  'ArgumentName',inportParameters{argIn,7});
-    end
+    setArgumentParameters(allArgIns,inportParameters);
     
     %% Convert Outports to ArgOuts
     
@@ -98,32 +88,24 @@ function subToSimFunc(subsystem,simulinkFunctionName,visibility)
     allArgOuts=find_system(subsystem,'SearchDepth',1,'BlockType','ArgOut');
     
     % Setting the parameters for all the argument outputs
-    for argOut=1:length(allArgOuts)
-        set_param(allArgOuts{argOut},'Port',outportParameters{argOut,1},...
-                  'OutMin',outportParameters{argOut,2},...
-                  'OutMax',outportParameters{argOut,3},...
-                  'OutDataTypeStr',outportParameters{argOut,4},...
-                  'LockScale',outportParameters{argOut,5},...
-                  'PortDimensions',outportParameters{argOut,6},...
-                  'ArgumentName',outportParameters{argOut,7});
-    end
+    setArgumentParameters(allArgOuts,outportParameters);
 end
 
 function parameters=getPortParameters(ports)
-% getPortParameters returns the parameters for an inport or outport
+% getPortParameters     Returns the parameters for an inport or outport
 %
 % Inputs:
-%   ports           Cell array of inports or outports
+%   ports               Cell array of inports or outports
 %
 % Outputs:
-%   parameters      Cell array of parameters including:
-%                       1) Port
-%                       2) OutMin
-%                       3) OutMax
-%                       4) OutDataTypeStr
-%                       5) LockScale
-%                       6) PortDimensions
-%                       7) ArgumentName
+%   parameters          Cell array of parameters including:
+%                           1) Port
+%                           2) OutMin
+%                           3) OutMax
+%                           4) OutDataTypeStr
+%                           5) LockScale
+%                           6) PortDimensions
+%                           7) ArgumentName
 %
 % Example:
 %   parameters=getPortParameters({'System/Subsystem/Inport1'})
@@ -180,5 +162,33 @@ function parameters=getPortParameters(ports)
             disp(['Invalid port variable name:',newline,splitPortPath{end},...
                    newline,'setting to ',parameters{port,7},newline])
         end
+    end
+end
+
+function setArgumentParameters(arguments,parameters)
+% setArgumentParameters     Sets argIn or ArgOut parameters
+%
+% Inputs:
+%   arguments               Cell array of argIns or argOuts
+%   parameters              Cell array of parameters for each argument
+%
+% Outputs:
+%   N/A
+%
+% Example:
+%   setArgumentParameters({'System/Subsystem/argIn1'},...
+%                         {'1','[]','[]','boolean','off','on','Inport1'})
+
+    %% Set the argument parameters
+    % Loop through each argument
+    for arg=1:length(arguments)
+        % Set the parameters for each argument
+        set_param(arguments{arg},'Port',parameters{arg,1},...
+                  'OutMin',parameters{arg,2},...
+                  'OutMax',parameters{arg,3},...
+                  'OutDataTypeStr',parameters{arg,4},...
+                  'LockScale',parameters{arg,5},...
+                  'PortDimensions',parameters{arg,6},...
+                  'ArgumentName',parameters{arg,7});
     end
 end

--- a/src/subToSimFcn.m
+++ b/src/subToSimFcn.m
@@ -1,4 +1,4 @@
-function subToSimFcn(subsystem,simulinkFcnName,visibility)
+function subToSimFcn(subsystem, simulinkFcnName, visibility)
 % subToSimFunc              Converts a subsystem to a Simulink Function
 %
 % Inputs:

--- a/src/subToSimFcn.m
+++ b/src/subToSimFcn.m
@@ -10,7 +10,7 @@ function subToSimFcn(subsystem, simulinkFcnName, visibility)
 %   N/A
 %
 % Example:
-%   subToSimFunc('Demo_Example/f_Sensor_Trip_1','f_Sensor_Trip_i', 'scoped')
+%   subToSimFunc('Demo_Example/f_Sensor_Trip_1', 'f_Sensor_Trip_i', 'scoped')
 %
 %           Converts 'f_Sensor_Trip_1' subsystem to a
 %           scoped Simulink-function 'f_SensorTrip_i'
@@ -118,8 +118,6 @@ function parameters = getPortParameters(ports)
 %                    {'1'} {'[]'} {'[]'} {'boolean'} {'off'} {'on'} {'Inport1'}
 
     %% Get the port parameters
-    % Init counter to counter invalid port names
-    invalidNameCounter = 0;
     % Init array of parameters for the ports
     parameters = cell(length(ports), 7);
     % Loop through each port
@@ -155,16 +153,7 @@ function parameters = getPortParameters(ports)
         % Get the port name by splitting the pathname by the backslash
         splitPortPath = split(ports{port}, '/');
         % Set port name equal to the last string in the split pathname
-        parameters{port, 7} = splitPortPath{end};
-        % If port name is invalid variable name, set to invalid name counter
-        try
-            assert(isvarname(parameters{port, 7}));
-        catch
-            invalidNameCounter = invalidNameCounter + 1;
-            parameters{port, 7} = strcat('arg', num2str(invalidNameCounter));
-            disp(['Invalid port variable name:', newline, splitPortPath{end},...
-                   newline, 'setting to ', parameters{port, 7}, newline])
-        end
+        parameters{port, 7} = genvarname(splitPortPath{end});
     end
 end
 

--- a/src/subToSimFcn.m
+++ b/src/subToSimFcn.m
@@ -153,7 +153,7 @@ function parameters = getPortParameters(ports)
         catch
             disp([portName, ...
                   ' dimension was set to ''-1''', ...
-                  ' - setting to ''1''...', newline]);
+                  ' - setting to ''1''...']);
             parameters{port, 6} = '1';
         end
         % Remove spaces from port name to create a valid variable name

--- a/src/subToSimFunc.m
+++ b/src/subToSimFunc.m
@@ -1,10 +1,10 @@
-function subToSimFunc(Subsystem,SimFunctionName,Visibility)
+function subToSimFunc(subsystem,simulinkFunctionName,visibility)
 % subToSimFunc converts a subsystem to a Simulink-function
 %
 % Inputs:
-%   Subsystem           Path of a subsystem to be converted
-%   SimFunctionName     Name of the Simulink-function to be created
-%   Visibility          Set function Visibility parameter to'scoped' or 'global'
+%   subsystem           Path of a subsystem to be converted
+%   simulinkFunctionName     Name of the Simulink-function to be created
+%   visibility          Set function Visibility parameter to'scoped' or 'global'
 %
 % Outputs:
 %   N/A
@@ -21,126 +21,134 @@ function subToSimFunc(Subsystem,SimFunctionName,Visibility)
     
     % Check that the subsystem is loaded
     try
-        assert(ischar(Subsystem));
-        assert(bdIsLoaded(bdroot(Subsystem)));
+        assert(ischar(subsystem));
+        assert(bdIsLoaded(bdroot(subsystem)));
     catch
         error('Invalid subsystem. Model may not be loaded or name is invalid.');
     end
     
     % Check that the function name is valid
     try
-        assert(isvarname(SimFunctionName));
+        assert(isvarname(simulinkFunctionName));
     catch
         error('Invalid function name. Use a valid MATLAB variable name.');
     end
     
     % Check that the function visibility is valid
     try
-        assert(strcmp(Visibility,'scoped')||strcmp(Visibility,'global'));
+        assert(strcmp(visibility,'scoped')||strcmp(visibility,'global'));
     catch
         error('Invalid function visibility. Use scoped/global visibility.');
     end
-
-    %% Init constants
-    
-    errorCounter = 0;
-    invalidNameCounter = 0;
     
     %% Convert Subsystem to Simulink-function
     
     % Disable subsystem link
-    set_param(Subsystem,'LinkStatus','inactive');
+    set_param(subsystem,'LinkStatus','inactive');
 
     % Adding the trigger block to the subsystem and calibrating its parameters
-    TriggerPath=append(Subsystem,'/',SimFunctionName);
+    TriggerPath=append(subsystem,'/',simulinkFunctionName);
     add_block('simulink/Ports & Subsystems/Trigger',TriggerPath);
-    set_param(TriggerPath,'TriggerType','function-call','IsSimulinkFunction' ...
-    ,'on','FunctionName',SimFunctionName,'FunctionVisibility',Visibility);
+    set_param(TriggerPath,'TriggerType','function-call','IsSimulinkFunction',...
+              'on','FunctionName',simulinkFunctionName,...
+              'FunctionVisibility',visibility);
     
     % Set subsystem to atomic execution
-    set_param(Subsystem,'TreatAsAtomicUnit','on');
+    set_param(subsystem,'TreatAsAtomicUnit','on');
     
     %% Convert Inports to ArgIns
     
+    % Create array of all the inports in the subsystem
+    allInports=find_system(subsystem,'SearchDepth',1,'BlockType','Inport');
+    
     % Getting the parameters for all inports in the subsystem
-    allInports=find_system(Subsystem,'SearchDepth',1,'BlockType','Inport');
-    inportParameters=cell(length(allInports),7);
-    for inport=1:length(allInports)
-        inportParameters{inport,1}=get_param(allInports{inport},'Port');
-        inportParameters{inport,2}=get_param(allInports{inport},'OutMin');
-        inportParameters{inport,3}=get_param(allInports{inport},'OutMax');
-        inportParameters{inport,4}=get_param(allInports{inport},'OutDataTypeStr');
-        if strcmp(inportParameters{inport,4},'Inherit: auto')
-            errorCounter = errorCounter+1;
-            inportParameters{inport,4}='double';
-            disp([num2str(errorCounter),'.',newline,'Data type of inport',newline,allInports{inport},newline,'was set to Inherit - setting to double...',newline]);
-        end
-        inportParameters{inport,5}=get_param(allInports{inport},'LockScale');
-        inportParameters{inport,6}=get_param(allInports{inport},'PortDimensions');
-        if strcmp(inportParameters{inport,6},'-1')
-            errorCounter = errorCounter+1;
-            inportParameters{inport,6}='1';
-            disp([num2str(errorCounter),'.',newline,'Port dimensions of inport',newline,allInports{inport},newline,'was set to Inherit - setting to 1...',newline]);
-        end
-        splitInportPath=split(allInports{inport},'/');
-        if isvarname(splitInportPath{end})
-            inportParameters{inport,7}=splitInportPath{end};
-        else
-            errorCounter = errorCounter+1;
-            invalidNameCounter = invalidNameCounter + 1;
-            inportParameters{inport,7}=strcat('arg',num2str(invalidNameCounter));
-            disp([num2str(errorCounter),'.',newline,'Invalid inport variable name',newline,splitInportPath{end},newline,'setting to ',inportParameters{inport,7},newline])
-        end
-    end
+    inportParameters=getPortParameters(allInports);
     
     % Replace inports with argument inputs
-    replace_block(Subsystem,'SearchDepth',1,'BlockType','Inport','ArgIn','noprompt');
+    replace_block(subsystem,'SearchDepth',1,'BlockType',...
+                  'Inport','ArgIn','noprompt');
+    
+    % Create array of all the argIns in the Simulink-function
+    allArgIns=find_system(subsystem,'SearchDepth',1,'BlockType','ArgIn');
     
     % Setting the parameters for all the argument inputs
-    allArgIns=find_system(Subsystem,'SearchDepth',1,'BlockType','ArgIn');
     for argIn=1:length(allArgIns)
-        set_param(allArgIns{argIn},'Port',inportParameters{argIn,1},'OutMin',inportParameters{argIn,2},'OutMax',inportParameters{argIn,3},'OutDataTypeStr',inportParameters{argIn,4},'LockScale',inportParameters{argIn,5},'PortDimensions',inportParameters{argIn,6},'ArgumentName',inportParameters{argIn,7});
+        set_param(allArgIns{argIn},'Port',inportParameters{argIn,1},...
+                  'OutMin',inportParameters{argIn,2},...
+                  'OutMax',inportParameters{argIn,3},...
+                  'OutDataTypeStr',inportParameters{argIn,4},...
+                  'LockScale',inportParameters{argIn,5},....
+                  'PortDimensions',inportParameters{argIn,6},...
+                  'ArgumentName',inportParameters{argIn,7});
     end
     
     %% Convert Outports to ArgOuts
     
+    % Create array of all the outports in the subsystem
+    allOutports=find_system(subsystem,'SearchDepth',1,'BlockType','Outport');
+    
     % Getting the parameters for all outports in the subsystem
-    allOutports=find_system(Subsystem,'SearchDepth',1,'BlockType','Outport');
-    outputParameters=cell(length(allInports),7);
-    for outport=1:length(allOutports)
-        outputParameters{outport,1}=get_param(allOutports{outport},'Port');
-        outputParameters{outport,2}=get_param(allOutports{outport},'OutMin');
-        outputParameters{outport,3}=get_param(allOutports{outport},'OutMax');
-        outputParameters{outport,4}=get_param(allOutports{outport},'OutDataTypeStr');
-        if strcmp(outputParameters{outport,4},'Inherit: auto')
-            errorCounter = errorCounter + 1;
-            outputParameters{outport,4}='double';
-            disp([num2str(errorCounter),'.',newline,'Data type of outport',newline,allOutports{outport},newline,'was set to Inherit - setting to double...',newline]);
-        end
-        outputParameters{outport,5}=get_param(allOutports{outport},'LockScale');
-        outputParameters{outport,6}=get_param(allOutports{outport},'PortDimensions');
-        if strcmp(outputParameters{outport,6},'-1')
-            errorCounter = errorCounter+1;
-            outputParameters{outport,6}='1';
-            disp([num2str(errorCounter),'.',newline,'Port dimensions of outport',newline,allOutports{outport},newline,'was set to Inherit - setting to 1...',newline]);
-        end
-        splitOutportPath=split(allOutports{outport},'/');
-        if isvarname(splitOutportPath{end})
-            outputParameters{outport,7}=splitOutportPath{end};
-        else
-            errorCounter = errorCounter + 1;
-            invalidNameCounter = invalidNameCounter + 1;
-            outputParameters{outport,7}=strcat('arg',num2str(invalidNameCounter));
-            disp([num2str(errorCounter),'.',newline,'Invalid outport variable name',newline,splitOutportPath{end},newline,'setting to ',outputParameters{outport,7},newline])
-        end
-    end
+    outportParameters=getPortParameters(allOutports);
     
     % Replace outports with argument outputs
-    replace_block(Subsystem,'SearchDepth',1,'BlockType','Outport','ArgOut','noprompt');
+    replace_block(subsystem,'SearchDepth',1,'BlockType','Outport','ArgOut','noprompt');
+    
+    % Create array of all the argOuts for the Simulink-function
+    allArgOuts=find_system(subsystem,'SearchDepth',1,'BlockType','ArgOut');
     
     % Setting the parameters for all the argument outputs
-    allArgOuts=find_system(Subsystem,'SearchDepth',1,'BlockType','ArgOut');
     for argOut=1:length(allArgOuts)
-        set_param(allArgOuts{argOut},'Port',outputParameters{argOut,1},'OutMin',outputParameters{argOut,2},'OutMax',outputParameters{argOut,3},'OutDataTypeStr',outputParameters{argOut,4},'LockScale',outputParameters{argOut,5},'PortDimensions',outputParameters{argOut,6},'ArgumentName',outputParameters{argOut,7});
+        set_param(allArgOuts{argOut},'Port',outportParameters{argOut,1},'OutMin',outportParameters{argOut,2},'OutMax',outportParameters{argOut,3},'OutDataTypeStr',outportParameters{argOut,4},'LockScale',outportParameters{argOut,5},'PortDimensions',outportParameters{argOut,6},'ArgumentName',outportParameters{argOut,7});
+    end
+end
+
+function parameters=getPortParameters(ports)
+    % Init counter to counter invalid port names
+    invalidNameCounter=0;
+    % Init array of parameters for the ports
+    parameters=cell(length(ports),7);
+    % Loop through each port
+    for port=1:length(ports)
+        % Get the port number
+        parameters{port,1}=get_param(ports{port},'Port');
+        % Get the port minimum output
+        parameters{port,2}=get_param(ports{port},'OutMin');
+        % Get the port maximum output
+        parameters{port,3}=get_param(ports{port},'OutMax');
+        % Get the port data type
+        parameters{port,4}=get_param(ports{port},'OutDataTypeStr');
+        % If data type is set to inherit, set to double by default
+        try
+            assert(not(strcmp(parameters{port,4},'Inherit: auto')));
+        catch
+            disp(['Data type of port',newline,ports{port},newline,...
+                  'was set to Inherit - setting to double...',newline]);
+            parameters{port,4}='double';
+        end
+        % Get the port lock scale
+        parameters{port,5}=get_param(ports{port},'LockScale');
+        % Get the port dimension
+        parameters{port,6}=get_param(ports{port},'PortDimensions');
+        % If port dimension is set to inherit, set to 1 by default
+        try
+            assert(not(strcmp(parameters{port,6},'-1')))
+        catch
+            disp(['Port dimensions of port:',newline,ports{port},newline,...
+                  'was set to Inherit - setting to 1...',newline]);
+            parameters{port,6}='1';
+        end
+        % Get the port name by splitting the pathname by the backslash
+        splitPortPath=split(ports{port},'/');
+        % Set port name equal to the last string in the split pathname
+        parameters{port,7}=splitPortPath{end};
+        % If port name is invalid variable name, set to invalid name counter
+        try
+            assert(isvarname(parameters{port,7}));
+        catch
+            invalidNameCounter = invalidNameCounter + 1;
+            parameters{port,7}=strcat('arg',num2str(invalidNameCounter));
+            disp(['Invalid port variable name',newline,splitPortPath{end},...
+            newline,'setting to ',parameters{port,7},newline])
+        end
     end
 end

--- a/src/subToSimFunc.m
+++ b/src/subToSimFunc.m
@@ -91,18 +91,48 @@ function subToSimFunc(subsystem,simulinkFunctionName,visibility)
     outportParameters=getPortParameters(allOutports);
     
     % Replace outports with argument outputs
-    replace_block(subsystem,'SearchDepth',1,'BlockType','Outport','ArgOut','noprompt');
+    replace_block(subsystem,'SearchDepth',1,'BlockType',...
+                  'Outport','ArgOut','noprompt');
     
     % Create array of all the argOuts for the Simulink-function
     allArgOuts=find_system(subsystem,'SearchDepth',1,'BlockType','ArgOut');
     
     % Setting the parameters for all the argument outputs
     for argOut=1:length(allArgOuts)
-        set_param(allArgOuts{argOut},'Port',outportParameters{argOut,1},'OutMin',outportParameters{argOut,2},'OutMax',outportParameters{argOut,3},'OutDataTypeStr',outportParameters{argOut,4},'LockScale',outportParameters{argOut,5},'PortDimensions',outportParameters{argOut,6},'ArgumentName',outportParameters{argOut,7});
+        set_param(allArgOuts{argOut},'Port',outportParameters{argOut,1},...
+                  'OutMin',outportParameters{argOut,2},...
+                  'OutMax',outportParameters{argOut,3},...
+                  'OutDataTypeStr',outportParameters{argOut,4},...
+                  'LockScale',outportParameters{argOut,5},...
+                  'PortDimensions',outportParameters{argOut,6},...
+                  'ArgumentName',outportParameters{argOut,7});
     end
 end
 
 function parameters=getPortParameters(ports)
+% getPortParameters returns the parameters for an inport or outport
+%
+% Inputs:
+%   ports           Cell array of inports or outports
+%
+% Outputs:
+%   parameters      Cell array of parameters including:
+%                       1) Port
+%                       2) OutMin
+%                       3) OutMax
+%                       4) OutDataTypeStr
+%                       5) LockScale
+%                       6) PortDimensions
+%                       7) ArgumentName
+%
+% Example:
+%   parameters=getPortParameters({'System/Subsystem/Inport1'})
+%
+%           ans = 
+%                1x7 cell array
+%                    {'1'} {'[]'} {'[]'} {'boolean'} {'off'} {'on'} {'Inport1'}
+
+    %% Get the port parameters
     % Init counter to counter invalid port names
     invalidNameCounter=0;
     % Init array of parameters for the ports
@@ -121,7 +151,7 @@ function parameters=getPortParameters(ports)
         try
             assert(not(strcmp(parameters{port,4},'Inherit: auto')));
         catch
-            disp(['Data type of port',newline,ports{port},newline,...
+            disp(['Invalid data type of port',newline,ports{port},newline,...
                   'was set to Inherit - setting to double...',newline]);
             parameters{port,4}='double';
         end
@@ -133,8 +163,8 @@ function parameters=getPortParameters(ports)
         try
             assert(not(strcmp(parameters{port,6},'-1')))
         catch
-            disp(['Port dimensions of port:',newline,ports{port},newline,...
-                  'was set to Inherit - setting to 1...',newline]);
+            disp(['Invalid port dimensions of port:',newline,ports{port},...
+                   newline,'was set to Inherit - setting to 1...',newline]);
             parameters{port,6}='1';
         end
         % Get the port name by splitting the pathname by the backslash
@@ -147,8 +177,8 @@ function parameters=getPortParameters(ports)
         catch
             invalidNameCounter = invalidNameCounter + 1;
             parameters{port,7}=strcat('arg',num2str(invalidNameCounter));
-            disp(['Invalid port variable name',newline,splitPortPath{end},...
-            newline,'setting to ',parameters{port,7},newline])
+            disp(['Invalid port variable name:',newline,splitPortPath{end},...
+                   newline,'setting to ',parameters{port,7},newline])
         end
     end
 end

--- a/src/subToSimFunc.m
+++ b/src/subToSimFunc.m
@@ -1,0 +1,146 @@
+function subToSimFunc(Subsystem,SimFunctionName,Visibility)
+% subToSimFunc converts a subsystem to a Simulink-function
+%
+% Inputs:
+%   Subsystem           Path of a subsystem to be converted
+%   SimFunctionName     Name of the Simulink-function to be created
+%   Visibility          Set function Visibility parameter to'scoped' or 'global'
+%
+% Outputs:
+%   N/A
+%
+% Example:
+%   subToSimFunc('Demo_Example/f_Sensor_Trip_1','f_Sensor_Trip_i', 'scoped')
+%
+%           Converts 'f_Sensor_Trip_1' subsystem to a
+%           scoped Simulink-function 'f_SensorTrip_i'
+%
+% Author: Stephen Scott
+
+    %% Input Validation
+    
+    % Check that the subsystem is loaded
+    try
+        assert(ischar(Subsystem));
+        assert(bdIsLoaded(bdroot(Subsystem)));
+    catch
+        error('Invalid subsystem. Model may not be loaded or name is invalid.');
+    end
+    
+    % Check that the function name is valid
+    try
+        assert(isvarname(SimFunctionName));
+    catch
+        error('Invalid function name. Use a valid MATLAB variable name.');
+    end
+    
+    % Check that the function visibility is valid
+    try
+        assert(strcmp(Visibility,'scoped')||strcmp(Visibility,'global'));
+    catch
+        error('Invalid function visibility. Use scoped/global visibility.');
+    end
+
+    %% Init constants
+    
+    errorCounter = 0;
+    invalidNameCounter = 0;
+    
+    %% Convert Subsystem to Simulink-function
+    
+    % Disable subsystem link
+    set_param(Subsystem,'LinkStatus','inactive');
+
+    % Adding the trigger block to the subsystem and calibrating its parameters
+    TriggerPath=append(Subsystem,'/',SimFunctionName);
+    add_block('simulink/Ports & Subsystems/Trigger',TriggerPath);
+    set_param(TriggerPath,'TriggerType','function-call','IsSimulinkFunction' ...
+    ,'on','FunctionName',SimFunctionName,'FunctionVisibility',Visibility);
+    
+    % Set subsystem to atomic execution
+    set_param(Subsystem,'TreatAsAtomicUnit','on');
+    
+    %% Convert Inports to ArgIns
+    
+    % Getting the parameters for all inports in the subsystem
+    allInports=find_system(Subsystem,'SearchDepth',1,'BlockType','Inport');
+    inportParameters=cell(length(allInports),7);
+    for inport=1:length(allInports)
+        inportParameters{inport,1}=get_param(allInports{inport},'Port');
+        inportParameters{inport,2}=get_param(allInports{inport},'OutMin');
+        inportParameters{inport,3}=get_param(allInports{inport},'OutMax');
+        inportParameters{inport,4}=get_param(allInports{inport},'OutDataTypeStr');
+        if strcmp(inportParameters{inport,4},'Inherit: auto')
+            errorCounter = errorCounter+1;
+            inportParameters{inport,4}='double';
+            disp([num2str(errorCounter),'.',newline,'Data type of inport',newline,allInports{inport},newline,'was set to Inherit - setting to double...',newline]);
+        end
+        inportParameters{inport,5}=get_param(allInports{inport},'LockScale');
+        inportParameters{inport,6}=get_param(allInports{inport},'PortDimensions');
+        if strcmp(inportParameters{inport,6},'-1')
+            errorCounter = errorCounter+1;
+            inportParameters{inport,6}='1';
+            disp([num2str(errorCounter),'.',newline,'Port dimensions of inport',newline,allInports{inport},newline,'was set to Inherit - setting to 1...',newline]);
+        end
+        splitInportPath=split(allInports{inport},'/');
+        if isvarname(splitInportPath{end})
+            inportParameters{inport,7}=splitInportPath{end};
+        else
+            errorCounter = errorCounter+1;
+            invalidNameCounter = invalidNameCounter + 1;
+            inportParameters{inport,7}=strcat('arg',num2str(invalidNameCounter));
+            disp([num2str(errorCounter),'.',newline,'Invalid inport variable name',newline,splitInportPath{end},newline,'setting to ',inportParameters{inport,7},newline])
+        end
+    end
+    
+    % Replace inports with argument inputs
+    replace_block(Subsystem,'SearchDepth',1,'BlockType','Inport','ArgIn','noprompt');
+    
+    % Setting the parameters for all the argument inputs
+    allArgIns=find_system(Subsystem,'SearchDepth',1,'BlockType','ArgIn');
+    for argIn=1:length(allArgIns)
+        set_param(allArgIns{argIn},'Port',inportParameters{argIn,1},'OutMin',inportParameters{argIn,2},'OutMax',inportParameters{argIn,3},'OutDataTypeStr',inportParameters{argIn,4},'LockScale',inportParameters{argIn,5},'PortDimensions',inportParameters{argIn,6},'ArgumentName',inportParameters{argIn,7});
+    end
+    
+    %% Convert Outports to ArgOuts
+    
+    % Getting the parameters for all outports in the subsystem
+    allOutports=find_system(Subsystem,'SearchDepth',1,'BlockType','Outport');
+    outputParameters=cell(length(allInports),7);
+    for outport=1:length(allOutports)
+        outputParameters{outport,1}=get_param(allOutports{outport},'Port');
+        outputParameters{outport,2}=get_param(allOutports{outport},'OutMin');
+        outputParameters{outport,3}=get_param(allOutports{outport},'OutMax');
+        outputParameters{outport,4}=get_param(allOutports{outport},'OutDataTypeStr');
+        if strcmp(outputParameters{outport,4},'Inherit: auto')
+            errorCounter = errorCounter + 1;
+            outputParameters{outport,4}='double';
+            disp([num2str(errorCounter),'.',newline,'Data type of outport',newline,allOutports{outport},newline,'was set to Inherit - setting to double...',newline]);
+        end
+        outputParameters{outport,5}=get_param(allOutports{outport},'LockScale');
+        outputParameters{outport,6}=get_param(allOutports{outport},'PortDimensions');
+        if strcmp(outputParameters{outport,6},'-1')
+            errorCounter = errorCounter+1;
+            outputParameters{outport,6}='1';
+            disp([num2str(errorCounter),'.',newline,'Port dimensions of outport',newline,allOutports{outport},newline,'was set to Inherit - setting to 1...',newline]);
+        end
+        splitOutportPath=split(allOutports{outport},'/');
+        if isvarname(splitOutportPath{end})
+            outputParameters{outport,7}=splitOutportPath{end};
+        else
+            errorCounter = errorCounter + 1;
+            invalidNameCounter = invalidNameCounter + 1;
+            outputParameters{outport,7}=strcat('arg',num2str(invalidNameCounter));
+            disp([num2str(errorCounter),'.',newline,'Invalid outport variable name',newline,splitOutportPath{end},newline,'setting to ',outputParameters{outport,7},newline])
+        end
+    end
+    
+    % Replace outports with argument outputs
+    replace_block(Subsystem,'SearchDepth',1,'BlockType','Outport','ArgOut','noprompt');
+    
+    % Setting the parameters for all the argument outputs
+    allArgOuts=find_system(Subsystem,'SearchDepth',1,'BlockType','ArgOut');
+    for argOut=1:length(allArgOuts)
+        set_param(allArgOuts{argOut},'Port',outputParameters{argOut,1},'OutMin',outputParameters{argOut,2},'OutMax',outputParameters{argOut,3},'OutDataTypeStr',outputParameters{argOut,4},'LockScale',outputParameters{argOut,5},'PortDimensions',outputParameters{argOut,6},'ArgumentName',outputParameters{argOut,7});
+    end
+end


### PR DESCRIPTION
Three main edits:

1. Added isSubsystem.m
     - Checks if a block is a subsystem
     - Used in determining whether to display 'Convert Subsystem' in the Simulink context menu

2. Added subToSimFcn.m
     - Converts subsystem to Sim-fcn by adding a trigger port and swapping ports for arguments

3. Edited sl_customization.m
     - Added function callbacks for subToSimFcn