### PR TITLE
Changed the conditional logic for 'Convert Subsystem' in context menu

### DIFF
--- a/src/sl_customization.m
+++ b/src/sl_customization.m
@@ -16,7 +16,9 @@ function schemaFcns = getSLModuleTool(callbackInfo)
     elseif any(selectedFcns) && ~isempty(gcbs)
         schemaFcns{end+1} = @ChangeFcnScopeSchema;
         schemaFcns{end+1} = @FcnCreatorLocalSchema;
-    elseif isSubsystem(gcbs)
+    end
+    
+    if isSubsystem(gcbs) && ~isSimulinkFcn(gcbs)
         schemaFcns{end+1} = @ConvToSimFcnSchema;
     end
 end

--- a/src/sl_customization.m
+++ b/src/sl_customization.m
@@ -13,13 +13,11 @@ function schemaFcns = getSLModuleTool(callbackInfo)
         schemaFcns{end+1} = @FcnCreatorSchema;
         schemaFcns{end+1} = @GuidelineSchema;
         schemaFcns{end+1} = @InterfaceSchema;
+    elseif isSubsystem(gcbs) && ~isSimulinkFcn(gcbs) && ~isempty(gcbs)
+        schemaFcns{end+1} = @ConvToSimFcnSchema;
     elseif any(selectedFcns) && ~isempty(gcbs)
         schemaFcns{end+1} = @ChangeFcnScopeSchema;
         schemaFcns{end+1} = @FcnCreatorLocalSchema;
-    end
-    
-    if isSubsystem(gcbs) && ~isSimulinkFcn(gcbs)
-        schemaFcns{end+1} = @ConvToSimFcnSchema;
     end
 end
 


### PR DESCRIPTION
 Fixed #2 by altering the conditional logic in getSLModuleTool which should now allow a subsystem to be converted regardless of if currently in a Simulink Function.

Achieved by only checking if the current selected block is a subsystem and not a Simulink Function.