### PR TITLE
Store and Re-load Interface Object

### DIFF
--- a/src/Interface/Interface.m
+++ b/src/Interface/Interface.m
@@ -59,7 +59,7 @@ classdef Interface
             end
         end
         function path = getFilePath(obj)
-           path = obj.FilePath; 
+            path = obj.FilePath; 
         end
         function hdl = getHandle(obj)
             hdl = obj.RootSystemHandle;
@@ -542,6 +542,7 @@ classdef Interface
                 obj.InportHeader.Handle = Simulink.Annotation([obj.ModelName '/' obj.InportHeader.Label], 'FontSize', SMALLFONT).Handle;
                 for a = 1:length(obj.Inport)
                     obj.Inport(a).InterfaceHandle = get_param(obj.Inport(a).Fullpath, 'Handle');
+                    obj.Inport(a).InterfacePath = getfullname(obj.Inport(a).InterfaceHandle);
                     
                     % Convert lines to goto/from connections
                     lines = get_param(obj.Inport(a).Handle, 'LineHandles');
@@ -564,6 +565,7 @@ classdef Interface
                     
                     fromName = char(getDsts(obj.Inport(a).Handle, 'IncludeImplicit', 'off'));
                     obj.Inport(a).TerminatorHandle = get_param(fromName, 'Handle');
+                    obj.Inport(a).TerminatorPath = getfullname(obj.Inport(a).TerminatorHandle);
                 end
             end
             
@@ -703,6 +705,7 @@ classdef Interface
                 obj.OutportHeader.Handle = Simulink.Annotation([obj.ModelName '/' obj.OutportHeader.Label], 'FontSize', SMALLFONT).Handle;
                 for h = 1:length(obj.Outport)
                     obj.Outport(h).InterfaceHandle = get_param(obj.Outport(h).Fullpath, 'Handle');
+                    obj.Outport(h).InterfacePath = getfullname(obj.Outport(h).InterfaceHandle);
                     
                     % Convert line(s) to goto/from connection
                     lines = get_param(obj.Outport(h).Handle, 'LineHandles');
@@ -725,6 +728,7 @@ classdef Interface
                     
                     fromName = char(getSrcs(obj.Outport(h).Handle, 'IncludeImplicit', 'off'));
                     obj.Outport(h).GroundHandle = get_param(fromName, 'Handle');
+                    obj.Outport(h).GroundPath = getfullname(obj.Outport(h).GroundHandle);
                 end
             end
             
@@ -959,7 +963,6 @@ classdef Interface
                 warning('No elements on the interface.');
                 return
             end
-            obj = deleteInterfaceMat(obj);
             
             % Remove headings
             obj.InputHeader = delete(obj.InputHeader);
@@ -1022,6 +1025,8 @@ classdef Interface
                 set_param(obj.ModelName, 'Zoomfactor', 'FitSystem');
             catch
             end
+            % Delete the interface .mat
+            obj = deleteInterfaceMat(obj);
         end
         function obj = updateHandles(obj)
 
@@ -1244,7 +1249,7 @@ classdef Interface
         % DELETEINTERFACE Delete the interface mat
             filename = obj.FilePath;
             if isfile(filename)
-                delete(filename)
+                delete(filename);
             end
             obj.FilePath = '';
         end

--- a/src/Interface/Interface.m
+++ b/src/Interface/Interface.m
@@ -7,7 +7,6 @@ classdef Interface
 
     properties
         ModelName
-        FileName
         
         % INPUTS
         Inport          InterfaceItem  
@@ -47,18 +46,20 @@ classdef Interface
         
         % Other
         RootSystemHandle
+        FilePath
     end
     methods (Access = public)
         function obj = Interface(m)
             if nargin == 0
                 obj.ModelName = '';
-                obj.FileName = '';
             elseif nargin == 1
                 obj.ModelName = bdroot(m);
                 obj.RootSystemHandle = get_param(obj.ModelName, 'Handle');
                 obj = autoAdd(obj);
-                obj.FileName = saveInterfaceMat(obj);
             end
+        end
+        function path = getFilePath(obj)
+           path = obj.FilePath; 
         end
         function hdl = getHandle(obj)
             hdl = obj.RootSystemHandle;
@@ -958,7 +959,7 @@ classdef Interface
                 warning('No elements on the interface.');
                 return
             end
-            deleteInterfaceMat(obj);
+            obj = deleteInterfaceMat(obj);
             
             % Remove headings
             obj.InputHeader = delete(obj.InputHeader);
@@ -976,7 +977,7 @@ classdef Interface
             obj.FunctionHeader = delete(obj.FunctionHeader);            
             
             % Remove blocks
-            for a = 1:length(obj.Inport)                    
+            for a = 1:length(obj.Inport)    
                 obj.Inport(a) = deleteFromModel(obj.Inport(a));
             end
             
@@ -1036,6 +1037,17 @@ classdef Interface
             %       iter    Iterator object.
             
             iter = InterfaceIterator(obj);
+        end
+        function saveInterfaceMat(obj)
+        % SAVEINTERFACE Save the interface object to a mat file
+        % in the same directory as the model
+            sys = obj.ModelName;
+            syspath = get_param(sys, 'FileName');
+            [path, name, ~] = fileparts(syspath);
+            ext = '.mat';
+            filename = fullfile(path, [name '_Interface' ext]);
+            obj.FilePath = filename;
+            save(filename, 'obj')
         end
     end
     methods (Access = private)
@@ -1228,51 +1240,13 @@ classdef Interface
                 obj.FunctionHeader.Handle, ...
                 obj.Function.InterfaceHandle];          
         end
-        function filename = saveInterfaceMat(obj)
-        % SAVEINTERFACE Save the interface object to a mat file in the same directory
-        %   as the model and create a callback in the model to load the mat file everytime
-        %   the model is opened.
-            sys = obj.ModelName;
-            % Create the mat file
-            % TODO: Check if exists already
-            syspath = get_param(sys, 'FileName');
-            [path, name, ~] = fileparts(syspath);
-            ext = '.mat';
-            filename = fullfile(path, [name '_Interface' ext]);
-            save(filename, 'obj')
-
-            % Ensure model loads mat file
-            % TODO: Check if in callbacks alredy
-            callback = get_param(sys, 'PreLoadFcn');
-            if ~isempty(callback)
-                newcallback = [callback newline '% INTERFACE' newline 'load(''' filename ''');'];
-            else
-                newcallback = ['% INTERFACE' newline 'load(''' filename ''');'];
-            end
-            set_param(sys, 'PreLoadFcn', newcallback);
-        end
-        function deleteInterfaceMat(obj)
-        % DELETEINTERFACE Delete the interface mat and remove the callback in the model.
-            sys = obj.ModelName;
-            % Delete the mat file
-            syspath = get_param(sys, 'FileName');
-            [path, name, ~] = fileparts(syspath);
-            ext = '.mat';
-            filename = fullfile(path, [name '_Interface' ext]);
+        function obj = deleteInterfaceMat(obj)
+        % DELETEINTERFACE Delete the interface mat
+            filename = obj.FilePath;
             if isfile(filename)
                 delete(filename)
             end
-
-            % Delete callback
-            callback = get_param(sys, 'PreLoadFcn');
-            callback = regexp(callback, '[\f\n\r]', 'split');
-            idx = find(strcmp(callback, '% INTERFACE'));
-            if idx
-                callback{idx} = '';
-                callback{idx+1} = '';
-            end
-            callback = strjoin(callback, '\n');
-            set_param(sys, 'PreLoadFcn', callback);
+            obj.FilePath = '';
         end
     end
 end

--- a/src/Interface/InterfaceHeader.m
+++ b/src/Interface/InterfaceHeader.m
@@ -12,6 +12,7 @@ classdef InterfaceHeader
             % DELETE Delete the header from the model.
             %
             % Inputs:
+            obj = obj.update;
             try
                 delete(obj.Handle);
             catch ME
@@ -20,6 +21,18 @@ classdef InterfaceHeader
                 end
             end
             obj.Handle = [];
+        end
+        function obj = update(obj)
+
+            if isempty(obj.Handle)
+                return
+            end
+            
+            sys = bdroot(gcs);
+            path = [sys '/' obj.Label];
+            disp(['Before: ' obj.Handle]);
+            obj.Handle = get_param(path, 'Handle');
+            disp(['After: ' obj.Handle]);
         end
     end
 end

--- a/src/Interface/InterfaceHeader.m
+++ b/src/Interface/InterfaceHeader.m
@@ -30,9 +30,7 @@ classdef InterfaceHeader
             
             sys = bdroot(gcs);
             path = [sys '/' obj.Label];
-            disp(['Before: ' obj.Handle]);
             obj.Handle = get_param(path, 'Handle');
-            disp(['After: ' obj.Handle]);
         end
     end
 end

--- a/src/Interface/InterfaceItem.m
+++ b/src/Interface/InterfaceItem.m
@@ -270,6 +270,7 @@ classdef InterfaceItem
         function obj = deleteFromModel(obj)
             % DELETEFROMMODEL Delete the representation of the item in the
             % model.
+            obj = obj.updateHandle;
             if any2(strcmp(obj.BlockType, {'Inport', 'Outport'}))
                 obj = deleteGrndTrm(obj);
                 % Move inport/outport back
@@ -306,21 +307,35 @@ classdef InterfaceItem
             end
             
             try
-                if ~any2(strcmp(obj.BlockType, {'Inport', 'Outport'}))
-                    obj.InterfaceHandle = get_param(obj.InterfacePath, 'Handle');
-                end
+                obj.InterfaceHandle = get_param(obj.InterfacePath, 'Handle');
             catch
                 obj.InterfaceHandle = [];
             end
             
             try
-                obj.GroundHandle = get_param(obj.GroundPath, 'Handle');
+                for i = 1:length(obj.GroundHandle)
+                    if iscell(obj.GroundPath)
+                        g = obj.GroundPath{i};
+                    else
+                        g = obj.GroundPath;
+                    end
+                    g = get_param(g, 'Handle');
+                    obj.GroundHandle(i) = g;
+                end
             catch
                 obj.GroundHandle = [];
             end
             
             try
-                obj.TerminatorHandle = get_param(obj.TerminatorPath, 'Handle');
+                for j = 1:length(obj.TerminatorHandle)
+                    if iscell(obj.TerminatorPath)
+                        t = obj.TerminatorPath{j};
+                    else
+                        t = obj.TerminatorPath;
+                    end
+                    t = get_param(t, 'Handle');
+                    obj.TerminatorHandle(j) = t;
+                end
             catch
                 obj.TerminatorHandle = [];
             end
@@ -382,7 +397,6 @@ classdef InterfaceItem
             for j = 1:length(obj.TerminatorHandle)
                 t = obj.TerminatorHandle(j);
                 if ishandle(t)
-                                        
                     if strcmp(obj.BlockType, 'Inport')
                         goto2Line(bdroot(obj.Fullpath), obj.TerminatorHandle);
                     else
@@ -394,6 +408,7 @@ classdef InterfaceItem
             end
             obj.TerminatorHandle = [];
             obj.TerminatorPath = [];
+            
         end
     end
 end

--- a/src/sl_customization.m
+++ b/src/sl_customization.m
@@ -287,9 +287,8 @@ function showInterfaceCallback(callbackInfo)
     objName = [sys '_InterfaceObject'];
     eval(['global ' objName ';']);
     
-    if interface_exists(sys)
+    if interface_exists(sys) 
         eval([objName ' = load_interface(sys);']);
-        
         answer = questdlg('An interface already exists. Do you wish to replace it?', 'Interface Exists');
         if strcmp(answer, 'Yes')
             % Delete old representation
@@ -302,8 +301,8 @@ function showInterfaceCallback(callbackInfo)
     else
         eval([objName ' = Interface(sys);']);
         eval([objName ' = ' objName '.model();']);
-        eval([objName '.saveInterfaceMat;']);
     end
+    eval([objName '.saveInterfaceMat;']);
 end
 
 %% Define menu: Print Interface
@@ -343,13 +342,12 @@ function schema = DeleteInterface(callbackInfo)
 end
 
 function deleteInterfaceCallback(callbackInfo)
-    
     sys = bdroot(gcs);
     objName = [sys '_InterfaceObject'];
     eval(['global ' objName ';']);
     
     eval([objName ' = load_interface(sys);']);
-        
+    
     eval([objName ' = delete(' objName ');']);
     eval(['clear global ' objName ';']);
     
@@ -364,20 +362,26 @@ function filename = get_interface_filename(sys)
 end
 
 function e = interface_exists(sys)
+    % INTERFACE_EXISTS Determine if there exists an interface for a model.
+    objName = [sys '_InterfaceObject'];
+    eval(['global ' objName ';']);
+    eval(['objEmpty = isempty(' objName ');']);
     
     filename = get_interface_filename(sys);
     
-    if isfile(filename)
-        e = true;
+    if objEmpty
+        if isfile(filename)
+            e = true;
+        else
+            e = false;
+        end
     else
-        e = false;
+        e = true;
     end
 end
 
 function obj = load_interface(sys)
-    
     filename = get_interface_filename(sys);
-    
     if interface_exists(sys)
        obj = load(filename);
        obj = obj.obj;

--- a/src/sl_customization.m
+++ b/src/sl_customization.m
@@ -300,7 +300,7 @@ function showInterfaceCallback(callbackInfo)
         end
     else
         eval([objName ' = Interface(sys);']);
-        eval([objName ' = ' objName '.model();']);
+        eval([objName ' = ' objName '.model;']);
     end
     eval([objName '.saveInterfaceMat;']);
 end


### PR DESCRIPTION
### Summary
* Added interface functionality to save/delete an interface object to `ModelName_Interface.mat`
* Altered the `interface_exists()` to check if an interface `.mat` exists for the current model
* Updated the interface callbacks to load the interface object from the file if the file exists

### Testing Performed
1. Generate interface of various model references (i.e. interfaces with inports, outports, Simulink Functions)
1. Save model
1. Re-open model
1. Delete interface
1. Observed output: **No errors** - interface files and model representations successfully deleted